### PR TITLE
Fix link to Fedora page

### DIFF
--- a/www.linux.org.il-new-site/template-toolkit/src/get/index.html.tt2
+++ b/www.linux.org.il-new-site/template-toolkit/src/get/index.html.tt2
@@ -31,14 +31,14 @@
 </li>
 
 <li>
-<h2><a href="https://fedoraproject.org/he/">Fedora</a></h2>
+<h2><a href="https://getfedora.org/he/">Fedora</a></h2>
 <p>
 הפצה פופולרית מאוד, המיועדת למשתמש הביתי. זאת הפצת לינוקס המפותחת ע"י Red Hat יחד עם מפתחים אחרים מהעולם, והיא בעצם גרסא חדשה של ההפצה שנקראה בעבר Red Hat Linux. ההפצה הרשמית של Red Hat נקראת כיום Red Hat Enterprise Linux ויותר אינה מופצת בחינם.
 </p>
 <p class="more-links">
 מידע נוסף:
 
-<a href="https://fedoraproject.org/he/">
+<a href="https://getfedora.org/he/">
 אתר הבית</a>
 </p>
 


### PR DESCRIPTION
The old link (fedoraproject.org) just redirects to the new site
(getfedora.org), and loses the language handling (/he).
This patch fixes the link to the new URL.
