### PR TITLE
Fix the link to www.linux.org.il

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# www.linux.org.il’s sources.
+# [www.linux.org.il](www.linux.org.il)’s sources.
 
 [![Build Status](https://travis-ci.org/Hamakor/linux.org.il.svg?branch=master)](https://travis-ci.org/Hamakor/linux.org.il)
 


### PR DESCRIPTION
The link was to "www.linux.org.il's" and not to "www.linux.org.il".
